### PR TITLE
Remove trailing comma from static proptypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sublime-react-es6",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Marcus Bernales <marcusbernales@gmail.com>, Jonas Gebhardt <jonas.gebhardt@gmail.com>",
   "description": "Sublime Text helpers for ReactJS",
   "scripts": {

--- a/snippets/js/propTypes.sublime-snippet
+++ b/snippets/js/propTypes.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 static propTypes = {
 	${1}: React.PropTypes.${2:string}
-},
+}
 ]]></content>
     <tabTrigger>pt</tabTrigger>
     <scope>source.js</scope>


### PR DESCRIPTION
Seems to be the odd one out, and since it's static it's always being used within an ES6+ class - the comma breaks syntax.
